### PR TITLE
修复聚合api有依赖出现的结果丢失

### DIFF
--- a/pkg/proxy/dispatcher.go
+++ b/pkg/proxy/dispatcher.go
@@ -185,9 +185,11 @@ func (dn *dispatchNode) copyHeaderTo(ctx *fasthttp.RequestCtx) {
 }
 
 func (dn *dispatchNode) maybeDone() {
-	if nil != dn.wg {
+	if nil != dn.multiCtx {
 		dn.multiCtx.completePart(dn.node.meta.AttrName, dn.getResponseBody())
-		dn.wg.Done()
+		if nil != dn.wg {
+			dn.wg.Done()
+		}
 	}
 }
 


### PR DESCRIPTION
假设有如下3个接口
A->B->C
B依赖A的返回值，C依赖B的返回值，最终希望给前端返回这样的数据结构
```json
{
    "C": {}
}
```
目前manba在聚合api时做了如下处理：
在请求A的时候，使用channel把request传输到由worker执行
循环到B的时候，等待A的返回值，判断还剩与几个接口，如果只剩余1个接口，那么直接在当前goroutine执行请求

修复方案一：
统一使用 worker 来处理
```go
//if num-idx > 1 {
	wg = &sync.WaitGroup{}
//}
```

修复方案二：
maybeDone 处理
