### PR TITLE
修复Find函数匹配*

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -176,7 +176,6 @@ func (r *Route) Find(url []byte, method string, paramsFunc func(name, value []by
 	var matchesItem *routeItem
 	matchedIdx := 0
 
-OUTER:
 	for idx, node := range nodes {
 		for _, item := range target {
 			if item.urlMatches(node, &matchAllParams) {
@@ -186,11 +185,9 @@ OUTER:
 					paramsFunc(item.node.argName, node.value)
 				}
 
-				if !item.node.isMatchAllConstString() {
-					target = item.children // find in children
-				}
+				target = item.children // find in children
 
-				continue OUTER
+				break // jump to first loop
 			}
 		}
 	}

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -263,6 +263,16 @@ func TestFind(t *testing.T) {
 		URLPattern: "/(enum:on|off):action",
 		Method:     "*",
 	})
+	r.Add(&metapb.API{
+		ID:         5,
+		URLPattern: "/(enum:on|off):action",
+		Method:     "*",
+	})
+	r.Add(&metapb.API{
+		ID:         6,
+		URLPattern: "/test/*/test",
+		Method:     "*",
+	})
 
 	params := make(map[string][]byte, 0)
 	paramsFunc := func(name, value []byte) {
@@ -320,5 +330,14 @@ func TestFind(t *testing.T) {
 	id, _ = r.Find([]byte("/on/notmatches"), "GET", paramsFunc)
 	if id != 0 {
 		t.Errorf("expect not matched , but %d", id)
+	}
+	
+	params = make(map[string][]byte, 0)
+	id, _ = r.Find([]byte("/test/match/test"), "GET", paramsFunc)
+	if id != 6 {
+		t.Errorf("expect not matched , but %d", id)
+	}
+	if string(params["*"]) != "match" {
+		t.Errorf("expect not matched, should match /test/*/test")
 	}
 }


### PR DESCRIPTION
/test/*/test 无法匹配到 /test/ok/test

在两个节点匹配后，为什么是 * 就不继续匹配子节点了？这里我移除了这个判断