### PR TITLE
修复路由添加错误

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -114,7 +114,7 @@ func (r *Route) Add(api *metapb.API) error {
 	parent := r.root
 	matchedIdx := 0
 	for idx, node := range nodes {
-		if parent.matches(node) {
+		if idx == 0 && parent.matches(node) {
 			matchedIdx = idx
 			continue
 		}

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -176,6 +176,21 @@ func TestAdd(t *testing.T) {
 	if len(r.root.children) != 5 {
 		t.Errorf("expect 4 children but %d, %+v", len(r.root.children), r.root)
 	}
+
+	r.Add(&metapb.API{
+		ID:         6,
+		URLPattern: "/a/b/b/a",
+		Method:     "*",
+	})
+	r.Add(&metapb.API{
+		ID:         7,
+		URLPattern: "/a/b/b/c",
+		Method:     "*",
+	})
+	_, ok := r.Find([]byte("/a/b/b/c"), "*", nil)
+	if !ok {
+		t.Errorf("expected match /a/b/b/c, but not")
+	}
 }
 
 func TestFindWithStar(t *testing.T) {


### PR DESCRIPTION
添加
/a/b/b/c
/a/b/b/a

Add逻辑里面的 parent 会出错